### PR TITLE
Fix bug resulting in duplicated output rows

### DIFF
--- a/src/main/java/com/ruckuswireless/pentaho/kafka/consumer/KafkaConsumerStep.java
+++ b/src/main/java/com/ruckuswireless/pentaho/kafka/consumer/KafkaConsumerStep.java
@@ -97,6 +97,8 @@ public class KafkaConsumerStep extends BaseStep implements StepInterface {
 			incrementLinesRead();
 		}
 
+		final Object[] inputRow = r;
+
 		KafkaConsumerMeta meta = (KafkaConsumerMeta) smi;
 		final KafkaConsumerData data = (KafkaConsumerData) sdi;
 
@@ -115,19 +117,18 @@ public class KafkaConsumerStep extends BaseStep implements StepInterface {
 
 		try {
 			long timeout = meta.getTimeout();
-			final Object[][] rClosure = new Object[][] { r };
 
 			logDebug("Starting message consumption with overall timeout of " + timeout + "ms");
 
 			KafkaConsumerCallable kafkaConsumer = new KafkaConsumerCallable(meta, data, this) {
 				protected void messageReceived(byte[] message) throws KettleException {
-					rClosure[0] = RowDataUtil.addRowData(rClosure[0], data.inputRowMeta.size(),
+					Object[] newRow = RowDataUtil.addRowData(inputRow.clone(), data.inputRowMeta.size(),
 							new Object[] { message });
-					putRow(data.outputRowMeta, rClosure[0]);
+					putRow(data.outputRowMeta, newRow);
 
 					if (isRowLevel()) {
 						logRowlevel(Messages.getString("KafkaConsumerStep.Log.OutputRow",
-								Long.toString(getLinesWritten()), data.outputRowMeta.getString(rClosure[0])));
+								Long.toString(getLinesWritten()), data.outputRowMeta.getString(newRow)));
 					}
 				}
 			};


### PR DESCRIPTION
The mutation of the original "r" record in the output handling caused Kettle to
frequently duplicate rows when passing values to other transforms. Cloning
it (and cleaning things up a bit) will prevent the possibility of mutation.